### PR TITLE
asmdefs referenced by names and not GUIDs

### DIFF
--- a/Assets/Editor/UnityVolumeRendering.Editor.asmdef.meta
+++ b/Assets/Editor/UnityVolumeRendering.Editor.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0fc4bbbda06df9e49b20cb31ff594b40
+guid: 2a5bc6c7e57af084a9a550162dc6a26c
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/UnityVolumeRendering.asmdef
+++ b/Assets/UnityVolumeRendering.asmdef
@@ -1,3 +1,0 @@
-{
-	"name": "UnityVolumeRendering"
-}

--- a/UnityVolumeRendering.asmdef
+++ b/UnityVolumeRendering.asmdef
@@ -1,12 +1,8 @@
 {
-    "name": "UnityVolumeRendering.Editor",
+    "name": "UnityVolumeRendering",
     "rootNamespace": "",
-    "references": [
-        "UnityVolumeRendering"
-    ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "references": [],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/UnityVolumeRendering.asmdef.meta
+++ b/UnityVolumeRendering.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 20b627782ca250a42954d77285ac309b
+guid: 2a2e3b5ff535c7248b469bb3d494e59a
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
asmdefs referenced by names and not GUIDs. Using names will prevent breaking code when used as submodules.
Also, there was a redundant assembly file that we did not need. I remove it.